### PR TITLE
Add network multiplayer scripts

### DIFF
--- a/Assets/UDPReceiver.cs
+++ b/Assets/UDPReceiver.cs
@@ -32,10 +32,22 @@ public class UDPReceiver : MonoBehaviour
         {
             var data = client.Receive(ref anyIP);
             var msg = Encoding.UTF8.GetString(data);
-            var parts = msg.Split(',');
-            if (parts.Length < 2) continue;
 
-            if (float.TryParse(parts[0], out float yL) &&
+            if (msg.Contains(":"))
+            {
+                var p = msg.Split(':');
+                if (p.Length == 2 && float.TryParse(p[1], out float y))
+                {
+                    float norm = Mathf.Clamp01(1f - y / 480f) * 2f - 1f;
+                    if (p[0].StartsWith("L")) LeftY = norm;
+                    else if (p[0].StartsWith("R")) RightY = norm;
+                }
+                continue;
+            }
+
+            var parts = msg.Split(',');
+            if (parts.Length >= 2 &&
+                float.TryParse(parts[0], out float yL) &&
                 float.TryParse(parts[1], out float yR))
             {
                 float normL = Mathf.Clamp01(1f - yL / 480f);

--- a/PingPongLab.py
+++ b/PingPongLab.py
@@ -1,12 +1,19 @@
 import cv2
 import numpy as np
 import socket
+import argparse
 
-UDP_IP   = "127.0.0.1"
-UDP_PORT = 5065
+parser = argparse.ArgumentParser(description="Track two colors and send Y positions")
+parser.add_argument('--ip', default='127.0.0.1', help='IP of Unity host')
+parser.add_argument('--port', type=int, default=5065, help='UDP port')
+parser.add_argument('--camera', type=int, default=0, help='Camera index')
+args = parser.parse_args()
+
+UDP_IP   = args.ip
+UDP_PORT = args.port
 sock     = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-cap = cv2.VideoCapture(0, cv2.CAP_DSHOW)   # ó tu fuente
+cap = cv2.VideoCapture(args.camera, cv2.CAP_DSHOW)   # ó tu fuente
 w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
 h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
 
@@ -33,6 +40,11 @@ while True:
     maskR = cv2.inRange(hsv, red_lower1, red_upper1) | cv2.inRange(hsv, red_lower2, red_upper2)
     # --- azul ---
     maskB = cv2.inRange(hsv, blue_lower , blue_upper)
+
+    maskR = cv2.erode(maskR, None, iterations=2)
+    maskR = cv2.dilate(maskR, None, iterations=2)
+    maskB = cv2.erode(maskB, None, iterations=2)
+    maskB = cv2.dilate(maskB, None, iterations=2)
 
     posR = get_centroid(maskR)
     posB = get_centroid(maskB)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# CGVCM Lab B-09
+
+Este proyecto contiene un juego de ping pong en Unity controlado por
+scripts de Python mediante UDP. Se incluye un modo básico de seguimiento
+de colores y un cliente adicional para jugar desde otra computadora.
+
+## Requisitos
+- Unity 2022.3.47f1
+- Python 3.7+
+- Paquetes: `opencv-python` y `numpy`
+
+## Ejecución básica
+1. Instala las dependencias en tu entorno de Python:
+   ```bash
+   pip install opencv-python numpy
+   ```
+2. Ejecuta `PingPongLab.py` para detectar los marcadores rojo y azul. Por defecto
+   se envía a `127.0.0.1:5065`, pero puedes indicar la IP y el puerto:
+   ```bash
+   python PingPongLab.py --ip 192.168.0.10 --port 5065
+   ```
+3. Abre la escena **PingPongScene.unity** en Unity y presiona Play.
+
+## Modo multijugador en red
+Para que cada jugador use su propia cámara en diferentes equipos,
+utiliza el script `RemotePaddle.py` y envía la posición de un solo
+paddle indicando el lado:
+```bash
+python RemotePaddle.py --side L --color blue --ip 192.168.0.10
+```
+En el equipo que ejecuta Unity, `UDPReceiver` aceptará mensajes con el
+formato `L:valor` o `R:valor` para controlar las raquetas izquierda y
+derecha respectivamente.

--- a/RemotePaddle.py
+++ b/RemotePaddle.py
@@ -1,0 +1,75 @@
+import cv2
+import numpy as np
+import socket
+import argparse
+
+# HSV ranges for red and blue markers
+RED_LOWER1 = np.array([0, 120, 70])
+RED_UPPER1 = np.array([10, 255, 255])
+RED_LOWER2 = np.array([170, 120, 70])
+RED_UPPER2 = np.array([180, 255, 255])
+BLUE_LOWER = np.array([100, 150, 50])
+BLUE_UPPER = np.array([140, 255, 255])
+
+
+def get_centroid(mask):
+    cnts, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not cnts:
+        return None
+    c = max(cnts, key=cv2.contourArea)
+    if cv2.contourArea(c) < 300:
+        return None
+    M = cv2.moments(c)
+    return int(M['m10'] / M['m00']), int(M['m01'] / M['m00'])
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Send paddle position over UDP")
+    parser.add_argument('--ip', default='127.0.0.1', help='IP of Unity host')
+    parser.add_argument('--port', type=int, default=5065, help='UDP port')
+    parser.add_argument('--side', choices=['L', 'R'], required=True,
+                        help='Paddle side (L or R)')
+    parser.add_argument('--color', choices=['red', 'blue'], required=True,
+                        help='Color to track')
+    parser.add_argument('--camera', type=int, default=0, help='Camera index')
+    args = parser.parse_args()
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    cap = cv2.VideoCapture(args.camera, cv2.CAP_DSHOW)
+
+    if args.color == 'red':
+        lower1, upper1 = RED_LOWER1, RED_UPPER1
+        lower2, upper2 = RED_LOWER2, RED_UPPER2
+    else:
+        lower1, upper1 = BLUE_LOWER, BLUE_UPPER
+        lower2 = upper2 = None
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+
+        mask = cv2.inRange(hsv, lower1, upper1)
+        if lower2 is not None:
+            mask |= cv2.inRange(hsv, lower2, upper2)
+
+        mask = cv2.erode(mask, None, iterations=2)
+        mask = cv2.dilate(mask, None, iterations=2)
+
+        pos = get_centroid(mask)
+        if pos:
+            message = f"{args.side}:{pos[1]}".encode('utf-8')
+            sock.sendto(message, (args.ip, args.port))
+            cv2.circle(frame, pos, 8, (0, 255, 0), -1)
+
+        cv2.imshow('Remote Paddle', frame)
+        if cv2.waitKey(1) == 27:
+            break
+
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- allow PingPongLab to specify the host/port
- process single paddle messages in UDPReceiver
- add RemotePaddle client script
- document usage and multiplayer mode

## Testing
- `python -m py_compile PingPongLab.py RemotePaddle.py gameDemo.py`


------
https://chatgpt.com/codex/tasks/task_b_68633e5cca80832f81e871071762a942