### PR TITLE
Add AI paddle and async UDP

### DIFF
--- a/Assets/AIPaddle.cs
+++ b/Assets/AIPaddle.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody))]
+public class AIPaddle : MonoBehaviour
+{
+    public BallController ball;
+    [SerializeField] float speed = 8f;
+    const float LIMIT_Y = 5.5f;
+
+    void FixedUpdate()
+    {
+        if (ball == null) return;
+        float targetY = Mathf.Clamp(ball.transform.position.y, -LIMIT_Y, LIMIT_Y);
+        float newY = Mathf.MoveTowards(transform.position.y, targetY, speed * Time.fixedDeltaTime);
+        transform.position = new Vector3(transform.position.x, newY, transform.position.z);
+    }
+}

--- a/Assets/AIPaddle.cs.meta
+++ b/Assets/AIPaddle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d611c8d4d44470e830dc3d229e38bdf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/UDPReceiver.cs
+++ b/Assets/UDPReceiver.cs
@@ -1,14 +1,15 @@
 using UnityEngine;
-using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 public class UDPReceiver : MonoBehaviour
 {
     public static UDPReceiver Instance;
     UdpClient client;
-    Thread receiveThread;
+    CancellationTokenSource cts;
+    Task receiveTask;
     public float LeftY { get; private set; }
     public float RightY { get; private set; }
 
@@ -21,21 +22,29 @@ public class UDPReceiver : MonoBehaviour
     void Start()
     {
         client = new UdpClient(5065);
-        receiveThread = new Thread(ReceiveLoop) { IsBackground = true };
-        receiveThread.Start();
+        cts = new CancellationTokenSource();
+        receiveTask = ReceiveLoopAsync(cts.Token);
     }
 
-    void ReceiveLoop()
+    async Task ReceiveLoopAsync(CancellationToken token)
     {
-        var anyIP = new IPEndPoint(IPAddress.Any, 0);
-        while (true)
+        while (!token.IsCancellationRequested)
         {
-            var data = client.Receive(ref anyIP);
-            var msg = Encoding.UTF8.GetString(data);
-            var parts = msg.Split(',');
-            if (parts.Length < 2) continue;
+            UdpReceiveResult res;
+            try
+            {
+                res = await client.ReceiveAsync();
+            }
+            catch (ObjectDisposedException)
+            {
+                break;
+            }
+            var msg = Encoding.UTF8.GetString(res.Buffer);
 
-            if (float.TryParse(parts[0], out float yL) &&
+
+            var parts = msg.Split(',');
+            if (parts.Length >= 2 &&
+                float.TryParse(parts[0], out float yL) &&
                 float.TryParse(parts[1], out float yR))
             {
                 float normL = Mathf.Clamp01(1f - yL / 480f);
@@ -47,5 +56,11 @@ public class UDPReceiver : MonoBehaviour
         }
     }
 
-    void OnApplicationQuit() => receiveThread?.Abort();
+    void OnApplicationQuit()
+    {
+        cts?.Cancel();
+        client?.Close();
+    }
+
+    void OnDestroy() => OnApplicationQuit();
 }

--- a/PingPongLab.py
+++ b/PingPongLab.py
@@ -1,12 +1,19 @@
 import cv2
 import numpy as np
 import socket
+import argparse
 
-UDP_IP   = "127.0.0.1"
-UDP_PORT = 5065
+parser = argparse.ArgumentParser(description="Track two colors and send Y positions")
+parser.add_argument('--ip', default='127.0.0.1', help='IP of Unity host')
+parser.add_argument('--port', type=int, default=5065, help='UDP port')
+parser.add_argument('--camera', type=int, default=0, help='Camera index')
+args = parser.parse_args()
+
+UDP_IP   = args.ip
+UDP_PORT = args.port
 sock     = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
-cap = cv2.VideoCapture(0, cv2.CAP_DSHOW)   # ó tu fuente
+cap = cv2.VideoCapture(args.camera, cv2.CAP_DSHOW)   # ó tu fuente
 w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
 h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
 
@@ -33,6 +40,11 @@ while True:
     maskR = cv2.inRange(hsv, red_lower1, red_upper1) | cv2.inRange(hsv, red_lower2, red_upper2)
     # --- azul ---
     maskB = cv2.inRange(hsv, blue_lower , blue_upper)
+
+    maskR = cv2.erode(maskR, None, iterations=2)
+    maskR = cv2.dilate(maskR, None, iterations=2)
+    maskB = cv2.erode(maskB, None, iterations=2)
+    maskB = cv2.dilate(maskB, None, iterations=2)
 
     posR = get_centroid(maskR)
     posB = get_centroid(maskB)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# CGVCM Lab B-09
+
+Este proyecto contiene un juego de ping pong en Unity controlado por
+scripts de Python mediante UDP. Se incluye un modo básico de seguimiento
+de colores y un modo opcional de un jugador con IA.
+
+## Requisitos
+- Unity 2022.3.47f1
+- Python 3.7+
+- Paquetes: `opencv-python` y `numpy`
+
+## Ejecución básica
+1. Instala las dependencias en tu entorno de Python:
+   ```bash
+   pip install opencv-python numpy
+   ```
+2. Ejecuta `PingPongLab.py` para detectar los marcadores rojo y azul. Por defecto
+   se envía a `127.0.0.1:5065`, pero puedes indicar la IP y el puerto:
+   ```bash
+   python PingPongLab.py --ip 192.168.0.10 --port 5065
+   ```
+3. Abre la escena **PingPongScene.unity** en Unity y presiona Play.
+
+## Modo de un jugador con IA
+
+Agregamos el script `AIPaddle.cs` para que una raqueta pueda seguir
+automáticamente la posición de la pelota. Asigna el script al paddle
+que quieras automatizar y referencia la bola desde el Inspector.


### PR DESCRIPTION
## Summary
- refactor UDPReceiver to use async/await instead of a Thread
- cancel receiver cleanly on quit
- add `AIPaddle` component for single-player mode
- document the new AI script in README
- remove experimental RemotePaddle client

## Testing
- `python3 -m py_compile PingPongLab.py gameDemo.py`


------
https://chatgpt.com/codex/tasks/task_b_68633e5cca80832f81e871071762a942